### PR TITLE
Use a fixed size for PodcastChannelLogo

### DIFF
--- a/sailfish/qml/pages/PodcastEpisodesChannelInfo.qml
+++ b/sailfish/qml/pages/PodcastEpisodesChannelInfo.qml
@@ -30,8 +30,8 @@ Item {
             anchors.left: parent.left
             anchors.leftMargin: 0
             channelLogo: channel.logo
-            width: parent.width/4
-            height: parent.width/4
+            width: Theme.itemSizeHuge
+            height: Theme.itemSizeHuge
 
         }
 


### PR DESCRIPTION
This gives some more space for the episode listing in portrait mode